### PR TITLE
Skip installing file that's has been removed from the upstream source

### DIFF
--- a/ubuntu/debian/libgz-fuel-tools9.install
+++ b/ubuntu/debian/libgz-fuel-tools9.install
@@ -1,4 +1,3 @@
 usr/lib/*/*.so.*
 usr/lib/*/*/*.rb
-usr/share/gz/*/*.yaml
 usr/share/gz/*.completion*/*


### PR DESCRIPTION
The config.yaml is no longer installed by the upstream code as of https://github.com/gazebosim/gz-fuel-tools/pull/413.

This should fix https://build.osrfoundation.org/job/gz-fuel-tools9-debbuilder/396/